### PR TITLE
Remove unused auth-type parameter from Azure login step in workflow

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Log in to Azure
       uses: azure/login@v1
       with:
-        auth-type: IDENTITY
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUB_ID }}


### PR DESCRIPTION
This pull request modifies the Azure deployment workflow configuration to adjust authentication settings.

Workflow configuration updates:

* [`.github/workflows/deploy-to-azure.yml`](diffhunk://#diff-cf18ecc07678667b850fbe0e904da1950658c22cbedd4dbd44d9a13283dd3726L24): Removed the `auth-type: IDENTITY` parameter from the Azure login step, simplifying the authentication configuration.