### PR TITLE
Add timezone import for datetime handling in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,9 @@ import os
 from flask import Flask, request, jsonify
 import requests
 from dotenv import load_dotenv
-from datetime import datetime  # Add this import
+from datetime import datetime
+from datetime import timezone
+
 
 # Load environment variables from a .env file if it exists
 load_dotenv()


### PR DESCRIPTION
This pull request makes a small change to the imports in `main.py` by adding the `timezone` import from the `datetime` module. This prepares the codebase for potential future use of timezone-aware datetime objects.