### PR TITLE
Feature/sun moon display

### DIFF
--- a/home.py
+++ b/home.py
@@ -10,6 +10,7 @@ from flask import Blueprint, request, render_template
 
 from services import WeatherAPIProvider
 from services.safety_features import enrich_weather_data
+from services.astronomy_features import enrich_with_astronomy
 
 home_bp = Blueprint('home', __name__)
 logger = logging.getLogger(__name__)
@@ -48,6 +49,8 @@ def home():
             weather_data = service.get_detailed_forecast(location, days=10)
             # Enrich with safety features
             weather_data = enrich_weather_data(weather_data)
+            # Enrich with astronomy features
+            weather_data = enrich_with_astronomy(weather_data)
         except Exception as e:
             logger.error(f"Error fetching weather data for location '{location}': {e}", exc_info=True)
             error_message = f"Unable to fetch weather data for '{location}'. Please try a different location."

--- a/services/astronomy_features.py
+++ b/services/astronomy_features.py
@@ -1,0 +1,187 @@
+"""
+Astronomy features module for processing sun and moon data.
+
+This module enriches weather data with astronomy information including
+sunrise, sunset, moonrise, moonset, moon phase with emojis, and daylight duration.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any, List
+
+
+def get_moon_phase_emoji(phase: str) -> str:
+    """
+    Get emoji representation for moon phase.
+    
+    Args:
+        phase: Moon phase name (e.g., "New Moon", "First Quarter")
+    
+    Returns:
+        Emoji string representing the moon phase
+    """
+    phase_lower = phase.lower() if phase else ""
+    
+    moon_phases = {
+        "new moon": "🌑",
+        "waxing crescent": "🌒",
+        "first quarter": "🌓",
+        "waxing gibbous": "🌔",
+        "full moon": "🌕",
+        "waning gibbous": "🌖",
+        "last quarter": "🌗",
+        "waning crescent": "🌘",
+        "third quarter": "🌗",  # Alias for last quarter
+    }
+    
+    return moon_phases.get(phase_lower, "🌙")
+
+
+def calculate_daylight_duration(sunrise: str, sunset: str) -> Optional[str]:
+    """
+    Calculate daylight duration from sunrise and sunset times.
+    
+    Args:
+        sunrise: Sunrise time in format "HH:MM AM/PM"
+        sunset: Sunset time in format "HH:MM AM/PM"
+    
+    Returns:
+        Formatted string like "14h 23m" or None if calculation fails
+    """
+    if not sunrise or not sunset:
+        return None
+    
+    try:
+        # Parse 12-hour format times
+        sunrise_time = datetime.strptime(sunrise, "%I:%M %p")
+        sunset_time = datetime.strptime(sunset, "%I:%M %p")
+        
+        # Calculate duration
+        duration = sunset_time - sunrise_time
+        
+        # Handle cases where sunset is "before" sunrise (crosses midnight)
+        if duration.total_seconds() < 0:
+            duration = timedelta(days=1) + duration
+        
+        # Convert to hours and minutes
+        total_seconds = int(duration.total_seconds())
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        
+        return f"{hours}h {minutes}m"
+    except (ValueError, AttributeError):
+        return None
+
+
+def process_astronomy_day(day_data: Dict[str, Any], is_current_day: bool = False) -> Dict[str, Any]:
+    """
+    Process astronomy data for a single day.
+    
+    Args:
+        day_data: Forecast day data containing 'astro' field
+        is_current_day: Whether this is the current day
+    
+    Returns:
+        Dictionary with processed astronomy information
+    """
+    astro = day_data.get('astro', {})
+    
+    sunrise = astro.get('sunrise', '').strip()
+    sunset = astro.get('sunset', '').strip()
+    moonrise = astro.get('moonrise', '').strip()
+    moonset = astro.get('moonset', '').strip()
+    moon_phase = astro.get('moon_phase', '').strip()
+    moon_illumination = str(astro.get('moon_illumination', '')).strip()
+    
+    # Calculate daylight duration
+    daylight_duration = calculate_daylight_duration(sunrise, sunset)
+    
+    # Get moon phase emoji
+    moon_emoji = get_moon_phase_emoji(moon_phase)
+    
+    return {
+        'date': day_data.get('date', ''),
+        'is_current_day': is_current_day,
+        'sunrise': sunrise,
+        'sunset': sunset,
+        'moonrise': moonrise,
+        'moonset': moonset,
+        'has_moonrise': bool(moonrise and not moonrise.lower().startswith('no ')),
+        'has_moonset': bool(moonset and not moonset.lower().startswith('no ')),
+        'moon_phase': moon_phase,
+        'moon_phase_emoji': moon_emoji,
+        'moon_illumination': moon_illumination,
+        'daylight_duration': daylight_duration
+    }
+
+
+def get_astronomy_data(weather_data: Optional[Dict[str, Any]], include_current_day: bool = True) -> List[Dict[str, Any]]:
+    """
+    Extract and process astronomy data from weather forecast.
+    
+    Args:
+        weather_data: Weather data dictionary from API
+        include_current_day: Whether to include today in the results
+    
+    Returns:
+        List of processed astronomy data dictionaries
+    """
+    if not weather_data or 'forecast' not in weather_data:
+        return []
+    
+    forecast = weather_data['forecast']
+    if not forecast or 'forecastday' not in forecast:
+        return []
+    
+    forecastdays = forecast['forecastday']
+    if not forecastdays:
+        return []
+    
+    astronomy_data = []
+    today = datetime.now().date()
+    
+    for idx, day_data in enumerate(forecastdays):
+        try:
+            day_date = datetime.strptime(day_data.get('date', ''), '%Y-%m-%d').date()
+            is_current_day = (day_date == today)
+            
+            # Skip current day if requested
+            if is_current_day and not include_current_day:
+                continue
+            
+            processed = process_astronomy_day(day_data, is_current_day)
+            astronomy_data.append(processed)
+            
+        except (ValueError, AttributeError):
+            # Skip days with invalid date format
+            continue
+    
+    return astronomy_data
+
+
+def enrich_with_astronomy(weather_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    Enrich weather data with processed astronomy information.
+    
+    Adds 'astronomy_info' field with current day astronomy and
+    'astronomy_forecast' with 5-day forecast (excluding current day).
+    
+    Args:
+        weather_data: Weather data dictionary from API
+    
+    Returns:
+        Enriched weather data or None if input is None
+    """
+    if not weather_data:
+        return None
+    
+    # Get current day astronomy
+    current_astronomy = get_astronomy_data(weather_data, include_current_day=True)
+    if current_astronomy:
+        weather_data['astronomy_info'] = current_astronomy[0]
+    
+    # Get multi-day astronomy forecast (excluding current day, next 5 days)
+    all_astronomy = get_astronomy_data(weather_data, include_current_day=False)
+    # Limit to next 5 days
+    weather_data['astronomy_forecast'] = all_astronomy[:5]
+    
+    return weather_data

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -802,3 +802,194 @@ fluent-message-bar {
         padding: var(--spacing-sm);
     }
 }
+
+/* ========================================
+   Astronomy Section Styles
+   ======================================== */
+
+.astronomy-section {
+    margin-bottom: var(--spacing-lg);
+}
+
+.astronomy-card {
+    background: var(--app-surface);
+    border-radius: var(--border-radius);
+    box-shadow: var(--card-shadow);
+    padding: var(--spacing-lg);
+}
+
+.astronomy-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    padding-bottom: var(--spacing-md);
+    border-bottom: 1px solid #e1e1e1;
+}
+
+.astronomy-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--app-text-primary);
+    flex: 1;
+}
+
+.toggle-label {
+    font-size: 0.9rem;
+    color: var(--app-text-secondary);
+}
+
+/* Current Day View */
+.astronomy-current-view {
+    width: 100%;
+}
+
+.astronomy-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--spacing-lg);
+}
+
+.astronomy-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: #fafafa;
+    border-radius: var(--border-radius);
+    transition: background 0.2s ease;
+}
+
+.astronomy-item:hover {
+    background: #f0f0f0;
+}
+
+.astronomy-icon {
+    font-size: 2rem;
+    line-height: 1;
+}
+
+.astronomy-details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.astronomy-label {
+    font-size: 0.85rem;
+    color: var(--app-text-secondary);
+    font-weight: 500;
+}
+
+.astronomy-value {
+    font-size: 1.1rem;
+    color: var(--app-text-primary);
+    font-weight: 600;
+}
+
+.astronomy-subvalue {
+    font-size: 0.75rem;
+    color: var(--app-text-secondary);
+}
+
+/* Multi-Day View */
+.astronomy-multi-day-view {
+    width: 100%;
+}
+
+.astronomy-forecast-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+}
+
+.astronomy-forecast-day {
+    padding: var(--spacing-md);
+    background: #fafafa;
+    border-radius: var(--border-radius);
+    border-left: 4px solid var(--app-primary-color);
+}
+
+.forecast-day-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-md);
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid #e1e1e1;
+}
+
+.forecast-day-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--app-text-primary);
+}
+
+.forecast-day-date {
+    font-size: 0.85rem;
+    color: var(--app-text-secondary);
+}
+
+.astronomy-forecast-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: var(--spacing-sm);
+}
+
+.astronomy-mini-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm);
+    background: white;
+    border-radius: 4px;
+}
+
+.astronomy-mini-item.moon-phase-item {
+    grid-column: span 2;
+}
+
+.mini-icon {
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.mini-value {
+    font-size: 0.85rem;
+    color: var(--app-text-primary);
+    font-weight: 500;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .astronomy-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: var(--spacing-md);
+    }
+    
+    .astronomy-forecast-grid {
+        grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+    }
+}
+
+@media (max-width: 480px) {
+    .astronomy-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .astronomy-header {
+        flex-wrap: wrap;
+    }
+    
+    .astronomy-title {
+        font-size: 1.3rem;
+    }
+    
+    .astronomy-forecast-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .astronomy-mini-item.moon-phase-item {
+        grid-column: span 2;
+    }
+}

--- a/templates/components/astronomy.html
+++ b/templates/components/astronomy.html
@@ -1,0 +1,147 @@
+<!-- Astronomy Component: Sunrise, Sunset, Moonrise, Moonset, Moon Phase -->
+{% set astronomy_info = weather_data.astronomy_info %}
+{% set astronomy_forecast = weather_data.astronomy_forecast %}
+{% if astronomy_info %}
+<div class="astronomy-section">
+    <fluent-card class="astronomy-card">
+        <div class="astronomy-header">
+            <h3 class="astronomy-title">☀️ Sun & Moon</h3>
+            {% if astronomy_forecast %}
+            <fluent-switch id="astronomyMultiDayToggle" aria-label="Toggle extended astronomy outlook"></fluent-switch>
+            <span class="toggle-label">Extended Outlook</span>
+            {% endif %}
+        </div>
+
+        <!-- Current Day View (Default) -->
+        <div id="astronomyCurrentView" class="astronomy-current-view">
+            <div class="astronomy-grid">
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">🌅</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Sunrise</span>
+                        <span class="astronomy-value">{{ astronomy_info.sunrise }}</span>
+                    </div>
+                </div>
+
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">🌇</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Sunset</span>
+                        <span class="astronomy-value">{{ astronomy_info.sunset }}</span>
+                    </div>
+                </div>
+
+                {% if astronomy_info.daylight_duration %}
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">☀️</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Daylight</span>
+                        <span class="astronomy-value">{{ astronomy_info.daylight_duration }}</span>
+                    </div>
+                </div>
+                {% endif %}
+
+                {% if astronomy_info.has_moonrise %}
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">🌄</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Moonrise</span>
+                        <span class="astronomy-value">{{ astronomy_info.moonrise }}</span>
+                    </div>
+                </div>
+                {% endif %}
+
+                {% if astronomy_info.has_moonset %}
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">🌆</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Moonset</span>
+                        <span class="astronomy-value">{{ astronomy_info.moonset }}</span>
+                    </div>
+                </div>
+                {% endif %}
+
+                <div class="astronomy-item">
+                    <div class="astronomy-icon">{{ astronomy_info.moon_phase_emoji }}</div>
+                    <div class="astronomy-details">
+                        <span class="astronomy-label">Moon Phase</span>
+                        <span class="astronomy-value">{{ astronomy_info.moon_phase }}</span>
+                        {% if astronomy_info.moon_illumination %}
+                        <span class="astronomy-subvalue">{{ astronomy_info.moon_illumination }}% illuminated</span>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Multi-Day View (Hidden by default) -->
+        {% if astronomy_forecast %}
+        <div id="astronomyMultiDayView" class="astronomy-multi-day-view" style="display: none;">
+            <div class="astronomy-forecast-list">
+                {% for day in astronomy_forecast %}
+                <div class="astronomy-forecast-day">
+                    <div class="forecast-day-header">
+                        <span class="forecast-day-name">{{ day.date | format_date }}</span>
+                        <span class="forecast-day-date">{{ day.date }}</span>
+                    </div>
+                    <div class="astronomy-forecast-grid">
+                        <div class="astronomy-mini-item">
+                            <span class="mini-icon">🌅</span>
+                            <span class="mini-value">{{ day.sunrise }}</span>
+                        </div>
+                        <div class="astronomy-mini-item">
+                            <span class="mini-icon">🌇</span>
+                            <span class="mini-value">{{ day.sunset }}</span>
+                        </div>
+                        {% if day.daylight_duration %}
+                        <div class="astronomy-mini-item">
+                            <span class="mini-icon">☀️</span>
+                            <span class="mini-value">{{ day.daylight_duration }}</span>
+                        </div>
+                        {% endif %}
+                        {% if day.has_moonrise %}
+                        <div class="astronomy-mini-item">
+                            <span class="mini-icon">🌄</span>
+                            <span class="mini-value">{{ day.moonrise }}</span>
+                        </div>
+                        {% endif %}
+                        {% if day.has_moonset %}
+                        <div class="astronomy-mini-item">
+                            <span class="mini-icon">🌆</span>
+                            <span class="mini-value">{{ day.moonset }}</span>
+                        </div>
+                        {% endif %}
+                        <div class="astronomy-mini-item moon-phase-item">
+                            <span class="mini-icon">{{ day.moon_phase_emoji }}</span>
+                            <span class="mini-value">{{ day.moon_phase }}</span>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+    </fluent-card>
+</div>
+
+<script>
+// Toggle between current day and multi-day astronomy view
+(function() {
+    const toggle = document.getElementById('astronomyMultiDayToggle');
+    if (!toggle) return;
+
+    const currentView = document.getElementById('astronomyCurrentView');
+    const multiDayView = document.getElementById('astronomyMultiDayView');
+
+    toggle.addEventListener('change', function() {
+        if (toggle.checked) {
+            currentView.style.display = 'none';
+            multiDayView.style.display = 'block';
+        } else {
+            currentView.style.display = 'block';
+            multiDayView.style.display = 'none';
+        }
+    });
+})();
+</script>
+{% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -63,6 +63,11 @@
         </fluent-card>
     </div>
 
+    <!-- Astronomy Section -->
+    {% if weather_data.astronomy_info %}
+    {% include 'components/astronomy.html' with context %}
+    {% endif %}
+
     <!-- Safety Metrics Section (moved after forecast) -->
     <div class="safety-metrics-section">
         {% if weather_data.uv_info %}

--- a/test_astronomy.py
+++ b/test_astronomy.py
@@ -1,0 +1,308 @@
+"""
+Tests for astronomy features module.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from services.astronomy_features import (
+    get_moon_phase_emoji,
+    calculate_daylight_duration,
+    process_astronomy_day,
+    get_astronomy_data,
+    enrich_with_astronomy
+)
+
+
+class TestMoonPhaseEmoji:
+    """Test moon phase emoji mapping."""
+    
+    def test_new_moon(self):
+        assert get_moon_phase_emoji("New Moon") == "🌑"
+    
+    def test_full_moon(self):
+        assert get_moon_phase_emoji("Full Moon") == "🌕"
+    
+    def test_first_quarter(self):
+        assert get_moon_phase_emoji("First Quarter") == "🌓"
+    
+    def test_waxing_crescent(self):
+        assert get_moon_phase_emoji("Waxing Crescent") == "🌒"
+    
+    def test_waning_gibbous(self):
+        assert get_moon_phase_emoji("Waning Gibbous") == "🌖"
+    
+    def test_case_insensitive(self):
+        assert get_moon_phase_emoji("FULL MOON") == "🌕"
+        assert get_moon_phase_emoji("new moon") == "🌑"
+    
+    def test_unknown_phase(self):
+        assert get_moon_phase_emoji("Unknown Phase") == "🌙"
+    
+    def test_empty_phase(self):
+        assert get_moon_phase_emoji("") == "🌙"
+    
+    def test_none_phase(self):
+        assert get_moon_phase_emoji(None) == "🌙"
+
+
+class TestDaylightDuration:
+    """Test daylight duration calculation."""
+    
+    def test_normal_calculation(self):
+        result = calculate_daylight_duration("06:30 AM", "05:45 PM")
+        assert result == "11h 15m"
+    
+    def test_long_day(self):
+        result = calculate_daylight_duration("05:00 AM", "09:00 PM")
+        assert result == "16h 0m"
+    
+    def test_short_day(self):
+        result = calculate_daylight_duration("08:00 AM", "04:30 PM")
+        assert result == "8h 30m"
+    
+    def test_noon_times(self):
+        result = calculate_daylight_duration("12:00 PM", "11:59 PM")
+        assert result == "11h 59m"
+    
+    def test_midnight_crossing(self):
+        # This shouldn't happen in real data, but test edge case
+        result = calculate_daylight_duration("11:00 PM", "01:00 AM")
+        assert result == "2h 0m"
+    
+    def test_empty_sunrise(self):
+        result = calculate_daylight_duration("", "05:45 PM")
+        assert result is None
+    
+    def test_empty_sunset(self):
+        result = calculate_daylight_duration("06:30 AM", "")
+        assert result is None
+    
+    def test_none_inputs(self):
+        result = calculate_daylight_duration(None, None)
+        assert result is None
+    
+    def test_invalid_format(self):
+        result = calculate_daylight_duration("6:30", "17:45")
+        assert result is None
+
+
+class TestProcessAstronomyDay:
+    """Test processing astronomy data for a single day."""
+    
+    def test_complete_data(self):
+        day_data = {
+            'date': '2024-01-15',
+            'astro': {
+                'sunrise': '07:30 AM',
+                'sunset': '05:15 PM',
+                'moonrise': '08:45 PM',
+                'moonset': '09:30 AM',
+                'moon_phase': 'First Quarter',
+                'moon_illumination': '50'
+            }
+        }
+        
+        result = process_astronomy_day(day_data, is_current_day=True)
+        
+        assert result['date'] == '2024-01-15'
+        assert result['is_current_day'] is True
+        assert result['sunrise'] == '07:30 AM'
+        assert result['sunset'] == '05:15 PM'
+        assert result['moonrise'] == '08:45 PM'
+        assert result['moonset'] == '09:30 AM'
+        assert result['has_moonrise'] is True
+        assert result['has_moonset'] is True
+        assert result['moon_phase'] == 'First Quarter'
+        assert result['moon_phase_emoji'] == '🌓'
+        assert result['moon_illumination'] == '50'
+        assert result['daylight_duration'] == '9h 45m'
+    
+    def test_no_moonrise(self):
+        day_data = {
+            'date': '2024-06-15',
+            'astro': {
+                'sunrise': '04:30 AM',
+                'sunset': '09:45 PM',
+                'moonrise': 'No moonrise',
+                'moonset': '02:30 PM',
+                'moon_phase': 'Full Moon',
+                'moon_illumination': '100'
+            }
+        }
+        
+        result = process_astronomy_day(day_data)
+        
+        assert result['has_moonrise'] is False
+        assert result['has_moonset'] is True
+    
+    def test_no_moonset(self):
+        day_data = {
+            'date': '2024-12-20',
+            'astro': {
+                'sunrise': '08:00 AM',
+                'sunset': '03:30 PM',
+                'moonrise': '10:00 AM',
+                'moonset': 'No moonset',
+                'moon_phase': 'Waning Crescent',
+                'moon_illumination': '25'
+            }
+        }
+        
+        result = process_astronomy_day(day_data)
+        
+        assert result['has_moonrise'] is True
+        assert result['has_moonset'] is False
+    
+    def test_missing_astro_data(self):
+        day_data = {
+            'date': '2024-01-15'
+        }
+        
+        result = process_astronomy_day(day_data)
+        
+        assert result['date'] == '2024-01-15'
+        assert result['sunrise'] == ''
+        assert result['sunset'] == ''
+        assert result['daylight_duration'] is None
+
+
+class TestGetAstronomyData:
+    """Test extracting astronomy data from weather forecast."""
+    
+    def test_valid_forecast_data(self):
+        today = datetime.now().date()
+        tomorrow = today + timedelta(days=1)
+        
+        weather_data = {
+            'forecast': {
+                'forecastday': [
+                    {
+                        'date': today.strftime('%Y-%m-%d'),
+                        'astro': {
+                            'sunrise': '07:00 AM',
+                            'sunset': '05:30 PM',
+                            'moonrise': '09:00 PM',
+                            'moonset': '10:00 AM',
+                            'moon_phase': 'New Moon',
+                            'moon_illumination': '5'
+                        }
+                    },
+                    {
+                        'date': tomorrow.strftime('%Y-%m-%d'),
+                        'astro': {
+                            'sunrise': '07:01 AM',
+                            'sunset': '05:31 PM',
+                            'moonrise': '09:30 PM',
+                            'moonset': '10:30 AM',
+                            'moon_phase': 'Waxing Crescent',
+                            'moon_illumination': '10'
+                        }
+                    }
+                ]
+            }
+        }
+        
+        result = get_astronomy_data(weather_data, include_current_day=True)
+        
+        assert len(result) == 2
+        assert result[0]['is_current_day'] is True
+        assert result[1]['is_current_day'] is False
+    
+    def test_exclude_current_day(self):
+        today = datetime.now().date()
+        tomorrow = today + timedelta(days=1)
+        
+        weather_data = {
+            'forecast': {
+                'forecastday': [
+                    {
+                        'date': today.strftime('%Y-%m-%d'),
+                        'astro': {'sunrise': '07:00 AM', 'sunset': '05:30 PM'}
+                    },
+                    {
+                        'date': tomorrow.strftime('%Y-%m-%d'),
+                        'astro': {'sunrise': '07:01 AM', 'sunset': '05:31 PM'}
+                    }
+                ]
+            }
+        }
+        
+        result = get_astronomy_data(weather_data, include_current_day=False)
+        
+        assert len(result) == 1
+        assert result[0]['is_current_day'] is False
+    
+    def test_empty_weather_data(self):
+        result = get_astronomy_data(None)
+        assert result == []
+    
+    def test_no_forecast(self):
+        weather_data = {'location': {'name': 'Test'}}
+        result = get_astronomy_data(weather_data)
+        assert result == []
+
+
+class TestEnrichWithAstronomy:
+    """Test enriching weather data with astronomy information."""
+    
+    def test_enrich_complete_data(self):
+        today = datetime.now().date()
+        future_dates = [today + timedelta(days=i) for i in range(1, 6)]
+        
+        weather_data = {
+            'location': {'name': 'Test City'},
+            'forecast': {
+                'forecastday': [
+                    {
+                        'date': today.strftime('%Y-%m-%d'),
+                        'astro': {
+                            'sunrise': '07:00 AM',
+                            'sunset': '05:30 PM',
+                            'moonrise': '09:00 PM',
+                            'moonset': '10:00 AM',
+                            'moon_phase': 'Full Moon',
+                            'moon_illumination': '98'
+                        }
+                    }
+                ] + [
+                    {
+                        'date': date.strftime('%Y-%m-%d'),
+                        'astro': {
+                            'sunrise': '07:00 AM',
+                            'sunset': '05:30 PM',
+                            'moonrise': '09:00 PM',
+                            'moonset': '10:00 AM',
+                            'moon_phase': 'Waning Gibbous',
+                            'moon_illumination': '90'
+                        }
+                    }
+                    for date in future_dates
+                ]
+            }
+        }
+        
+        result = enrich_with_astronomy(weather_data)
+        
+        assert 'astronomy_info' in result
+        assert result['astronomy_info']['is_current_day'] is True
+        assert result['astronomy_info']['moon_phase'] == 'Full Moon'
+        
+        assert 'astronomy_forecast' in result
+        assert len(result['astronomy_forecast']) == 5
+        assert all(not day['is_current_day'] for day in result['astronomy_forecast'])
+    
+    def test_enrich_none_data(self):
+        result = enrich_with_astronomy(None)
+        assert result is None
+    
+    def test_enrich_preserves_other_data(self):
+        weather_data = {
+            'location': {'name': 'Test'},
+            'current': {'temp_c': 20},
+            'forecast': {'forecastday': []}
+        }
+        
+        result = enrich_with_astronomy(weather_data)
+        
+        assert result['location'] == {'name': 'Test'}
+        assert result['current'] == {'temp_c': 20}

--- a/test_astronomy_integration.py
+++ b/test_astronomy_integration.py
@@ -1,0 +1,203 @@
+"""
+Integration test to verify astronomy template rendering.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from main import app
+from datetime import datetime, timedelta
+
+
+@pytest.fixture
+def client():
+    app.testing = True
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def reset_weather_service():
+    """Reset the weather service singleton before each test."""
+    import forecast
+    import home
+    forecast._weather_service = None
+    home._weather_service = None
+    yield
+    forecast._weather_service = None
+    home._weather_service = None
+
+
+def _get_moon_phase_for_day(day_number):
+    """Helper to get moon phase based on day number in forecast."""
+    phases = ['Waxing Crescent', 'First Quarter', 'Waxing Gibbous', 
+              'Full Moon', 'Waning Gibbous', 'Last Quarter', 
+              'Waning Crescent', 'New Moon']
+    return phases[day_number % len(phases)]
+
+
+def create_mock_weather_response_with_astronomy():
+    """Create a complete mock weather response including astronomy data."""
+    today = datetime.now().date()
+    future_dates = [today + timedelta(days=i) for i in range(1, 10)]
+    
+    return {
+        'location': {
+            'name': 'London',
+            'region': 'City of London',
+            'country': 'UK',
+            'lat': 51.52,
+            'lon': -0.11
+        },
+        'current': {
+            'temp_c': 15.0,
+            'temp_f': 59.0,
+            'feelslike_c': 13.0,
+            'feelslike_f': 55.0,
+            'condition': {
+                'text': 'Partly cloudy',
+                'icon': '//cdn.weatherapi.com/weather/64x64/day/116.png'
+            },
+            'wind_kph': 15.0,
+            'wind_mph': 9.3,
+            'humidity': 72,
+            'uv': 3,
+            'vis_km': 10.0,
+            'pressure_mb': 1015.0
+        },
+        'forecast': {
+            'forecastday': [
+                {
+                    'date': today.strftime('%Y-%m-%d'),
+                    'day': {
+                        'condition': {
+                            'text': 'Partly cloudy',
+                            'icon': '//cdn.weatherapi.com/weather/64x64/day/116.png'
+                        },
+                        'maxtemp_c': 18.0,
+                        'maxtemp_f': 64.4,
+                        'mintemp_c': 12.0,
+                        'mintemp_f': 53.6,
+                        'daily_chance_of_rain': 20
+                    },
+                    'astro': {
+                        'sunrise': '07:30 AM',
+                        'sunset': '05:45 PM',
+                        'moonrise': '08:30 PM',
+                        'moonset': '09:15 AM',
+                        'moon_phase': 'Waxing Crescent',
+                        'moon_illumination': '15'
+                    }
+                }
+            ] + [
+                {
+                    'date': date.strftime('%Y-%m-%d'),
+                    'day': {
+                        'condition': {
+                            'text': 'Sunny',
+                            'icon': '//cdn.weatherapi.com/weather/64x64/day/113.png'
+                        },
+                        'maxtemp_c': 20.0,
+                        'maxtemp_f': 68.0,
+                        'mintemp_c': 14.0,
+                        'mintemp_f': 57.2,
+                        'daily_chance_of_rain': 10
+                    },
+                    'astro': {
+                        'sunrise': '07:29 AM',
+                        'sunset': '05:46 PM',
+                        'moonrise': '09:00 PM',
+                        'moonset': '10:00 AM',
+                        'moon_phase': _get_moon_phase_for_day(i),
+                        'moon_illumination': str(15 + i * 10)
+                    }
+                }
+                for i, date in enumerate(future_dates, start=1)
+            ]
+        },
+        'alerts': {'alert': []}
+    }
+
+
+@patch('services.weatherapi_provider.requests.get')
+def test_home_page_with_astronomy_data(mock_get, client):
+    """Test that home page includes astronomy data when location is provided."""
+    import os
+    os.environ['WEATHER_API_KEY'] = 'test_api_key'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = create_mock_weather_response_with_astronomy()
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+    
+    response = client.get('/?location=London')
+    
+    assert response.status_code == 200
+    html = response.data.decode('utf-8')
+    
+    # Check for astronomy section
+    assert 'astronomy-section' in html
+    assert 'Sun & Moon' in html
+    
+    # Check for current day astronomy data
+    assert '07:30 AM' in html  # sunrise
+    assert '05:45 PM' in html  # sunset
+    assert '08:30 PM' in html  # moonrise
+    assert '09:15 AM' in html  # moonset
+    assert 'Waxing Crescent' in html  # moon phase
+    
+    # Check for daylight duration
+    assert '10h 15m' in html  # calculated daylight
+    
+    # Check for multi-day toggle
+    assert 'astronomyMultiDayToggle' in html
+    assert 'Extended Outlook' in html
+    
+    # Check for moon phase emoji (should be in the HTML)
+    assert '🌒' in html or 'moon_phase_emoji' in html
+
+
+@patch('services.weatherapi_provider.requests.get')
+def test_astronomy_with_no_moonrise(mock_get, client):
+    """Test handling of polar regions with no moonrise/moonset."""
+    import os
+    os.environ['WEATHER_API_KEY'] = 'test_api_key'
+    
+    weather_data = create_mock_weather_response_with_astronomy()
+    # Simulate polar region with no moonrise
+    weather_data['forecast']['forecastday'][0]['astro']['moonrise'] = 'No moonrise'
+    weather_data['forecast']['forecastday'][0]['astro']['moonset'] = 'No moonset'
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = weather_data
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+    
+    response = client.get('/?location=NorthPole')
+    
+    assert response.status_code == 200
+    html = response.data.decode('utf-8')
+    
+    # Should still show sunrise/sunset
+    assert '07:30 AM' in html
+    assert '05:45 PM' in html
+    
+    # Moonrise/moonset should be hidden (has_moonrise/has_moonset is False)
+    # The template uses {% if astronomy_info.has_moonrise %} to conditionally show
+
+
+@patch('services.weatherapi_provider.requests.get')
+def test_home_page_without_location_no_astronomy(mock_get, client):
+    """Test that home page without location doesn't show astronomy section."""
+    response = client.get('/')
+    
+    assert response.status_code == 200
+    html = response.data.decode('utf-8')
+    
+    # Should not have astronomy section when no location
+    assert 'astronomy-section' not in html
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
This pull request adds a comprehensive astronomy feature to the weather app, providing users with detailed sun and moon information (such as sunrise, sunset, moonrise, moonset, moon phase, and daylight duration) for the current day and an extended multi-day outlook. The implementation includes backend data enrichment, a new processing module, frontend display components, and associated styling.

**Key changes:**

**Backend: Astronomy Data Processing and Integration**
- Introduced a new module `services/astronomy_features.py` that processes and enriches weather data with astronomy information, including sunrise, sunset, moonrise, moonset, moon phase (with emoji), and daylight duration. It exposes an `enrich_with_astronomy` function that adds this data to the weather response.
- Integrated the astronomy enrichment step into the main weather data pipeline in `home.py` by importing and applying `enrich_with_astronomy` after weather data is fetched and safety features are applied. [[1]](diffhunk://#diff-9bdb309e27156f7bf20d53c0f2d0cf5cc62c93d9066f451740f57f881b56b711R13) [[2]](diffhunk://#diff-9bdb309e27156f7bf20d53c0f2d0cf5cc62c93d9066f451740f57f881b56b711R52-R53)

**Frontend: Display and Interaction**
- Added a new Jinja component template `templates/components/astronomy.html` to display astronomy details for the current day and a toggleable multi-day outlook, including sunrise/sunset, moonrise/moonset, moon phase (with emoji), and daylight duration. Includes interactive toggle logic for switching views.
- Updated the main home page template (`templates/home.html`) to include the astronomy section if astronomy data is available.

**Styling**
- Added extensive CSS styles for the astronomy section, cards, grids, icons, and responsive layouts in `static/css/app.css` to ensure the astronomy feature is visually consistent and user-friendly across devices.