### PR TITLE
Fix Blazor Server interactive components not loading in Azure

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -141,3 +141,15 @@ jobs:
                 "AzureOpenAI__Deployment=${{ secrets.AZURE_OPENAI_DEPLOYMENT }}" \
                 "AzureOpenAI__ApiVersion=2024-10-21"
           fi
+
+      # Blazor Server uses a persistent SignalR circuit that must stay on the
+      # same replica for the lifetime of the browser session. Without sticky
+      # sessions, requests can be routed to a different replica that has no
+      # record of the circuit, silently preventing interactive components
+      # (search box, theme toggle, etc.) from connecting.
+      - name: Enable sticky sessions for Blazor Container App
+        run: |
+          az containerapp ingress sticky-sessions set \
+            --name "$BLAZOR_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --affinity sticky

--- a/WeatherBlazor/Program.cs
+++ b/WeatherBlazor/Program.cs
@@ -1,6 +1,7 @@
 using WeatherBlazor.Components;
 using WeatherBlazor.Services;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,7 +19,25 @@ builder.Services.AddHttpClient<IWeatherService, WeatherApiService>();
 builder.Services.AddHttpClient<IAIService, AzureOpenAIService>();
 builder.Services.AddScoped<ChatStateService>();
 
+// Trust the Azure Container Apps ingress proxy so the app sees the real
+// scheme (https) and client IP rather than the internal HTTP connection.
+// Without this, Blazor Server's antiforgery check rejects the SignalR
+// circuit negotiate request (Origin: https vs server-perceived http),
+// preventing the interactive circuit from connecting.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    // Azure Container Apps' proxy IPs are not fixed, so clear the default
+    // trusted-networks allowlist to accept forwarded headers from any proxy.
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 var app = builder.Build();
+
+// Must be first — populates Request.Scheme / RemoteIpAddress from
+// X-Forwarded-Proto / X-Forwarded-For before any other middleware runs.
+app.UseForwardedHeaders();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Problem

The Blazor app launched in Azure but the search box and dark/light mode toggle were missing. The page appeared to render but no interactive components worked.

## Root Cause

Azure Container Apps terminates TLS at the ingress — the container only ever receives plain HTTP. Without `UseForwardedHeaders()`, the app was unaware it was sitting behind HTTPS, which created this failure chain:

1. Browser loads the page over `https://` — SSR prerender works, so the page *looks* like it loaded
2. `blazor.web.js` tries to establish the SignalR interactive circuit via a POST to `/_blazor/negotiate`
3. Browser sends `Origin: https://yourapp.azurecontainerapps.io`
4. `UseAntiforgery()` sees the request as `http://` but the Origin as `https://` → **origin mismatch → 400 rejected**
5. Circuit never connects → `<fluent-search>` and `<fluent-switch>` remain as inert prerendered elements (invisible/non-functional)

## Fixes

### `WeatherBlazor/Program.cs`
- Added `ForwardedHeadersOptions` to trust `X-Forwarded-For` + `X-Forwarded-Proto` from any proxy (Azure CA proxy IPs are not fixed, so the default trusted-networks list is cleared)
- Added `app.UseForwardedHeaders()` as the **first** middleware so all downstream middleware (antiforgery, HSTS, HTTPS redirect) sees the correct scheme and client IP

### `.github/workflows/deploy-to-azure.yml`
- Added `az containerapp ingress sticky-sessions set --affinity sticky` after Blazor app deployment — Blazor Server's SignalR circuit **must** stay on the same replica for the browser session lifetime; without this, scale-out breaks all interactive components on any request routed to a different replica
